### PR TITLE
Update develop.cmake

### DIFF
--- a/cmake/develop.cmake
+++ b/cmake/develop.cmake
@@ -68,7 +68,7 @@ endif()
 
 option(ENABLE_MYSQL "Enable mysql" OFF)
 if (ENABLE_MYSQL)
-    include(cmake/mysql.cmake)
+    include(${ormpp_SOURCE_DIR}/cmake/mysql.cmake)
     message(STATUS "ENABLE_MYSQL")
     add_definitions(-DORMPP_ENABLE_MYSQL)
 endif()


### PR DESCRIPTION
增加mysql.cmake加载时的完整路径，使用和主cmakelists的工程同名的宏定义，保证主cmakelists构建能保持原状。

在作为非子文件夹包括到项目中使用的场景下，只需要定义宏，就可以正常使用，保证项目路径干净

## Summary by Sourcery

Build:
- Include mysql.cmake via ${ormpp_SOURCE_DIR}/cmake/mysql.cmake in develop.cmake for correct path resolution